### PR TITLE
[FIX] ai_oca_bridge: Enforce saving before executing it

### DIFF
--- a/ai_oca_bridge/static/src/components/chatter/chatter.esm.js
+++ b/ai_oca_bridge/static/src/components/chatter/chatter.esm.js
@@ -6,11 +6,9 @@ registerPatch({
     name: "Chatter",
     recordMethods: {
         async onClickAiBridge(aiBridge) {
-            if (this.isTemporary) {
-                const saved = await this.doSaveRecord();
-                if (!saved) {
-                    return;
-                }
+            const saved = await this.doSaveRecord();
+            if (!saved) {
+                return;
             }
             const result = await this.env.services.orm.call(
                 "ai.bridge",


### PR DESCRIPTION
You might send the payload with the old data.