### PR TITLE
[16.0][FIX] ai_oca_bridge token authentication

### DIFF
--- a/ai_oca_bridge/models/ai_bridge_execution.py
+++ b/ai_oca_bridge/models/ai_bridge_execution.py
@@ -155,24 +155,28 @@ class AiBridgeExecution(models.Model):
 
     def _get_auth(self):
         """Return authentication for the request."""
-        if self.ai_bridge_id.auth_type == "none":
+        if self.ai_bridge_id.auth_type in ["none", "token"]:
+            # Token auth is handled in _get_headers
             return None
         elif self.ai_bridge_id.auth_type == "basic":
             return (
                 self.ai_bridge_id.sudo().auth_username,
                 self.ai_bridge_id.sudo().auth_password,
             )
-        elif self.ai_bridge_id.auth_type == "token":
-            return {"Authorization": f"Bearer {self.ai_bridge_id.sudo().auth_token}"}
         else:
             raise ValueError(_("Unsupported authentication type."))
 
     def _get_headers(self):
         """Return headers for the request."""
-        return {
+        headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+        if self.ai_bridge_id.auth_type == "token":
+            headers.update(
+                {"Authorization": f"Bearer {self.ai_bridge_id.sudo().auth_token}"}
+            )
+        return headers
 
     def _generate_token(self):
         """Generate a token for async operations."""


### PR DESCRIPTION
This PR solves #16
It moves the handling of token authentication from `_get_auth` to `_get_headers`