### PR TITLE
[18.0][IMP] ai_oca_bridge_chatter: Messages with attachments do activate the bridge.

### DIFF
--- a/ai_oca_bridge_chatter/models/ai_bridge.py
+++ b/ai_oca_bridge_chatter/models/ai_bridge.py
@@ -28,5 +28,7 @@ class AiBridge(models.Model):
                 "subject": record.subject,
                 "date": record.date.isoformat(),
                 "author_name": record.author_id.name,
+                "attachment_ids": record.attachment_ids.ids,
+                "parent_id": record.parent_id.id if record.parent_id else False,
             }
         }

--- a/ai_oca_bridge_chatter/models/mail_channel.py
+++ b/ai_oca_bridge_chatter/models/mail_channel.py
@@ -9,8 +9,6 @@ class MailChannel(models.Model):
 
     def message_post(self, **kwargs):
         message = super().message_post(**kwargs)
-        if not message.body:
-            return message
         if message.author_id.user_ids.ai_bridge_id:
             # Don't answer AI agents
             return message


### PR DESCRIPTION
I believe the bridge should also be able to detect messages that only contain attachments. Additionally, I have added the attachment_ids key to the message payload, containing the IDs of the attachments so that the flow can use this information as needed.

@arielbarreiros96