### PR TITLE
[18.0][FIX] ai_oca_bridge: avoid crash when request charset is missing

### DIFF
--- a/ai_oca_bridge/controllers/ai.py
+++ b/ai_oca_bridge/controllers/ai.py
@@ -37,7 +37,7 @@ class AIController(http.Controller):
                 execution._process_response(
                     json.loads(
                         request.httprequest.get_data().decode(
-                            request.httprequest.charset
+                            getattr(request.httprequest, "charset", None) or "utf-8"
                         )
                     )
                 )


### PR DESCRIPTION
## Problem

The async callback endpoint `/ai/response/<execution_id>/<token>` decodes the raw request body with `request.httprequest.charset`.

In some environments, the wrapped request object does not expose a `charset` attribute, which causes the callback to crash with:

```text
AttributeError: 'Request' object has no attribute 'charset'
```

As a result, valid async callback payloads return HTTP 500 before `_process_response()` is reached.

## Reproduction

A direct callback request also fails with HTTP 500:

```
curl -i -X POST "http://localhost:8069/ai/response/138/809e2dac28368ac5491495e6a1e989cbb2595dbff55209bfe211f0ee253b27f8" \
  -H "Content-Type: application/json; charset=utf-8" \
  -d '{"body":"Record updated successfully."}'
HTTP/1.1 500 INTERNAL SERVER ERROR
Server: Werkzeug/3.0.1 Python/3.12.3
Date: Thu, 12 Mar 2026 12:46:49 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 265
Connection: close

<!doctype html>
<html lang=en>
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>
```

## Fix

Use a safe fallback to UTF-8 when the request object does not provide a charset:

```python
request.httprequest.get_data().decode(
    getattr(request.httprequest, "charset", None) or "utf-8"
)
```

## Result

Async callback payloads such as:

```json
{"body":"Record updated successfully"}
```

can be processed without crashing when `request.httprequest.charset` is missing.

## Additional context

Possibly fixes issue #54 