### PR TITLE
[16.0][FIX] ai_tool: _ai_get_date output_schema uses invalid JSON Schema type 'date'

### DIFF
--- a/ai_tool/models/ai_tool.py
+++ b/ai_tool/models/ai_tool.py
@@ -48,7 +48,7 @@ class AiTool(models.Model):
     @aitool(
         input_schema={},
         output_schema={
-            "date": {"type": "date"},
+            "date": {"type": "string", "format": "date"},
         },
     )
     def _ai_get_date(self):


### PR DESCRIPTION
The `_ai_get_date` output_schema uses `"type": "date"`, which isn't a valid JSON Schema type. JSON Schema only allows `string`, `number`, `integer`, `boolean`, `object`, `array`, and `null`. Date values should use `"type": "string"` with `"format": "date"`.

Changed the schema to `{"type": "string", "format": "date"}` — the correct JSON Schema representation for a date.

Fixes #88
