### PR TITLE
[19.0][FIX] checklog-odoo: ignore chrome teardown warnings

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING.*Killing chrome descendants-or-self.*


### PR DESCRIPTION
I did this separately from #95 at the request of @arielbarreiros96