### PR TITLE
[19.0][IMP] update dotfiles

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,7 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.35
+_commit: v1.44
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
-ci: GitHub
 convert_readme_fragments_to_markdown: true
 enable_checklog_odoo: true
 generate_requirements_txt: true
@@ -17,6 +16,7 @@ odoo_test_flavor: Both
 odoo_version: 19.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
+postgres_image: ''
 rebel_module_groups: []
 repo_description: ai
 repo_name: ai

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -9,6 +10,10 @@ on:
       - "19.0"
       - "19.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
@@ -16,7 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - "19.0"
       - "19.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
@@ -65,6 +69,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
+          path: /tmp/odoo_tests/${{ env.PGDATABASE }}
+          if-no-files-found: ignore
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.12
   node: "22.9.0"
 repos:
   - repo: local
@@ -38,12 +38,17 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md|\.prettierrc\.yml|\.eslintrc\.yml)$'
+        language: fail
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:
       - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
-    rev: f9b919b9868143135a9c9cb03021089cabba8223
+    rev: 31bdbd8e4cb94be6534f0e82b1cafb84a455f671
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -60,7 +65,7 @@ repos:
           - --convert-fragments-to-markdown
       - id: oca-gen-external-dependencies
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
@@ -123,7 +128,7 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.15
+    rev: v10.0.6
     hooks:
       - id: pylint_odoo
         name: pylint with optional checks

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest-required-authors=Odoo Community Association (OCA)
@@ -26,6 +29,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,
@@ -85,6 +89,7 @@ enable=anomalous-backslash-in-string,
     translation-format-interpolation,
     translation-format-truncated,
     translation-fstring-interpolation,
+    translation-injection,
     translation-not-lazy,
     translation-too-few-args,
     translation-too-many-args,
@@ -92,20 +97,11 @@ enable=anomalous-backslash-in-string,
     no-write-in-compute,
     # messages that do not cause the lint step to fail
     consider-merging-classes-inherited,
-    create-user-wo-reset-password,
-    dangerous-filter-wo-user,
     deprecated-module,
-    file-not-used,
     invalid-commit,
-    missing-manifest-dependency,
-    missing-newline-extrafiles,
     missing-readme,
-    no-utf8-coding-comment,
     odoo-addons-relative-import,
-    old-api7-method-defined,
     redefined-builtin,
-    too-complex,
-    unnecessary-utf8-coding-comment,
     manifest-external-assets
 
 

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -3,6 +3,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest-required-authors=Odoo Community Association (OCA)
@@ -18,6 +21,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,
@@ -77,6 +81,7 @@ enable=anomalous-backslash-in-string,
     translation-format-interpolation,
     translation-format-truncated,
     translation-fstring-interpolation,
+    translation-injection,
     translation-not-lazy,
     translation-too-few-args,
     translation-too-many-args,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 
+[![Support the OCA](https://odoo-community.org/readme-banner-image)](https://odoo-community.org/get-involved?utm_source=repo-readme)
+
+# ai
 [![Runboat](https://img.shields.io/badge/runboat-Try%20me-875A7B.png)](https://runboat.odoo-community.org/builds?repo=OCA/ai&target_branch=19.0)
 [![Pre-commit Status](https://github.com/OCA/ai/actions/workflows/pre-commit.yml/badge.svg?branch=19.0)](https://github.com/OCA/ai/actions/workflows/pre-commit.yml?query=branch%3A19.0)
 [![Build Status](https://github.com/OCA/ai/actions/workflows/test.yml/badge.svg?branch=19.0)](https://github.com/OCA/ai/actions/workflows/test.yml?query=branch%3A19.0)
@@ -6,8 +9,6 @@
 [![Translation Status](https://translation.odoo-community.org/widgets/ai-19-0/-/svg-badge.svg)](https://translation.odoo-community.org/engage/ai-19-0/?utm_source=widget)
 
 <!-- /!\ do not modify above this line -->
-
-# ai
 
 ai
 

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,5 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*
+    WARNING.* Missing widget: res_partner_many2one for field of type many2one.*

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "baseBranchPatterns": ["20.0", "19.0", "18.0", "17.0", "16.0"],
+  "enabledManagers": ["copier"]
+}


### PR DESCRIPTION
Updates the repo to oca-addons-repo-template v1.44 (was v1.35, from the initial branch commit on 2025-09-30). Among other things this brings the Killing chrome descendants-or-self ignore rule to checklog-odoo.cfg, which is what #97 was patching by hand.

As requested by @pedrobaeza  in #95.

Note: CI can't pass here on its own, the 19.0 branch has no addons yet, so manifestoo returns an empty list and oca_init_test_database runs odoo -i with no modules. The same commit is currently included in #95, where all checks are green.