### PR TITLE
[18.0][FIX] ai_oca_bridge: honor timeout from _execute_kwargs

### DIFF
--- a/ai_oca_bridge/README.rst
+++ b/ai_oca_bridge/README.rst
@@ -187,6 +187,10 @@ Contributors
   - Ariel Barreiros
   - Adria Hortoneda
 
+- `Escodoo <https://www.escodoo.com.br>`__
+
+  - Marcel Savegnago
+
 Maintainers
 -----------
 

--- a/ai_oca_bridge/models/ai_bridge_execution.py
+++ b/ai_oca_bridge/models/ai_bridge_execution.py
@@ -122,14 +122,16 @@ class AiBridgeExecution(models.Model):
             **kwargs,
         )
         payload = self._add_extra_payload_fields(payload)
+        request_kwargs = self._execute_kwargs(**kwargs)
+        timeout = request_kwargs.pop("timeout", 30)
         try:
             response = requests.post(
                 self.ai_bridge_id.url,
                 json=payload,
                 auth=self._get_auth(),
                 headers=self._get_headers(),
-                timeout=30,  # Default timeout, can be overridden by _execute_kwargs
-                **self._execute_kwargs(**kwargs),
+                timeout=timeout,
+                **request_kwargs,
             )
             self.result = response.content
             response.raise_for_status()

--- a/ai_oca_bridge/readme/CONTRIBUTORS.md
+++ b/ai_oca_bridge/readme/CONTRIBUTORS.md
@@ -10,3 +10,7 @@
 
   - Ariel Barreiros
   - Adria Hortoneda
+
+- [Escodoo](https://www.escodoo.com.br)
+
+  - Marcel Savegnago

--- a/ai_oca_bridge/tests/test_bridge.py
+++ b/ai_oca_bridge/tests/test_bridge.py
@@ -328,3 +328,24 @@ class TestBridge(TransactionCase):
         self.assertEqual(
             execution.payload["_id"], json.loads(execution.payload_txt)["_id"]
         )
+
+    def test_execute_timeout_from_kwargs(self):
+        """timeout via _execute_kwargs must not raise TypeError."""
+        execution = self.env["ai.bridge.execution"].create(
+            {
+                "ai_bridge_id": self.bridge.id,
+                "model_id": self.env["ir.model"]._get_id("res.partner"),
+                "res_id": self.partner.id,
+            }
+        )
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = b'{"ok": true}'
+        response.json.return_value = {"ok": True}
+        response.raise_for_status = mock.Mock()
+        with mock.patch("requests.post", return_value=response) as mock_post:
+            execution._execute()
+            self.assertEqual(mock_post.call_args.kwargs["timeout"], 30)
+            execution._execute(timeout=90)
+            self.assertEqual(mock_post.call_args.kwargs["timeout"], 90)
+            self.assertEqual(execution.state, "done")


### PR DESCRIPTION
## Summary
- Pop `timeout` from `_execute_kwargs` before calling `requests.post` so extensions can override the 30s default.
- The previous `timeout=30, **self._execute_kwargs()` combination raises `TypeError` whenever `_execute_kwargs` also returns `timeout`.
- Downstream modules (e.g. a per-bridge request timeout field) currently have to replicate `_execute` to avoid that conflict.

## Test plan
- [x] Unit test `test_execute_timeout_from_kwargs` covers default 30s and `timeout=90` via `_execute`.
- [ ] CI of this PR
- [ ] After merge, Escodoo `ai_oca_bridge_request_timeout` can drop its `_execute` replica and only inject timeout through `_execute_kwargs`.


Made with [Cursor](https://cursor.com)