### PR TITLE
[18.0][FIX] ai_oca_bridge: honor timeout from _execute_kwargs

### DIFF
--- a/ai_oca_bridge/models/ai_bridge_execution.py
+++ b/ai_oca_bridge/models/ai_bridge_execution.py
@@ -122,14 +122,16 @@ class AiBridgeExecution(models.Model):
             **kwargs,
         )
         payload = self._add_extra_payload_fields(payload)
+        request_kwargs = self._execute_kwargs(**kwargs)
+        timeout = request_kwargs.pop("timeout", 30)
         try:
             response = requests.post(
                 self.ai_bridge_id.url,
                 json=payload,
                 auth=self._get_auth(),
                 headers=self._get_headers(),
-                timeout=30,  # Default timeout, can be overridden by _execute_kwargs
-                **self._execute_kwargs(**kwargs),
+                timeout=timeout,
+                **request_kwargs,
             )
             self.result = response.content
             response.raise_for_status()

--- a/ai_oca_bridge/tests/test_bridge.py
+++ b/ai_oca_bridge/tests/test_bridge.py
@@ -328,3 +328,24 @@ class TestBridge(TransactionCase):
         self.assertEqual(
             execution.payload["_id"], json.loads(execution.payload_txt)["_id"]
         )
+
+    def test_execute_timeout_from_kwargs(self):
+        """timeout via _execute_kwargs must not raise TypeError."""
+        execution = self.env["ai.bridge.execution"].create(
+            {
+                "ai_bridge_id": self.bridge.id,
+                "model_id": self.env["ir.model"]._get_id("res.partner"),
+                "res_id": self.partner.id,
+            }
+        )
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = b'{"ok": true}'
+        response.json.return_value = {"ok": True}
+        response.raise_for_status = mock.Mock()
+        with mock.patch("requests.post", return_value=response) as mock_post:
+            execution._execute()
+            self.assertEqual(mock_post.call_args.kwargs["timeout"], 30)
+            execution._execute(timeout=90)
+            self.assertEqual(mock_post.call_args.kwargs["timeout"], 90)
+            self.assertEqual(execution.state, "done")


### PR DESCRIPTION
This pull request improves the handling of the `timeout` parameter in the `ai_bridge_execution` model and adds a corresponding test to ensure correct behavior. The main focus is to allow the `timeout` value to be overridden via keyword arguments, enhancing flexibility and preventing potential errors.

**Enhancements to timeout handling:**

* Updated the `_execute` method in `ai_bridge_execution.py` to extract the `timeout` value from keyword arguments, defaulting to 30 seconds if not provided, and ensuring it is passed correctly to the `requests.post` call.

**Testing improvements:**

* Added a new test `test_execute_timeout_from_kwargs` in `test_bridge.py` to verify that the `timeout` parameter can be set via keyword arguments and defaults to 30 when not specified. The test also checks that no `TypeError` is raised and that the execution state is correctly set to `"done"`.